### PR TITLE
docs: take global install from scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ A little Node.js dependency installer with the bare minimum features for module 
 
 ###### ToDo
 + Follow the spec of npm's [package-lock.json]
-+ `install [--global]`
 + Installing packages in multiple forked clusters
 
 ### Table of Contents
@@ -52,9 +51,6 @@ You can install either only `dependencies` or `devDependencies` by using `--only
 ```console
 $ dep install --only=prod
 ```
-
-#### `dep install --global`
-ToDo.
 
 ### Lock
 #### `dep lock`


### PR DESCRIPTION
I'd say `dep run` could cover this use case easily. Also, if users would like to install any package as a global command, they can make a directory in somewhere(e.g. `$HOME/packages`) and add `node_modules/.bin` to their PATH.

I will take `install --global` from the scope. Keeping size small is a value.